### PR TITLE
Fix RubyGems/Bundler2 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
-  - 2.3
 before_install:
   - gem install bundler -v `grep -A1 'BUNDLED WITH' Gemfile.lock | tail -1`
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.5
   - 2.4
   - 2.3
+before_install:
+  - gem install bundler -v `grep -A1 'BUNDLED WITH' Gemfile.lock | tail -1`
 script:
   - bundle exec rubocop --fail-fast
   - bundle exec rake


### PR DESCRIPTION
- RubyGems contained a bug that is triggered by Bundler2 on Ruby <= 2.5. This PR forces bundler to the version specified in the lock file before installing gems. Bug details here: https://bundler.io/blog/2019/05/14/
- Building against Ruby 2.3 (which has reached EOL) has been removed.
- Building against Ruby 2.7 (currently in preview) has been added.